### PR TITLE
feat: migrate to app-update 2.1.0 from deprecated play-core 1.9.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,8 @@
         <clobbers target="cordova.plugins.InAppUpdateManager" />
     </js-module>
     <platform name="android">
-        <framework src="com.google.android.play:core:1.9.1" />
+        <framework src="com.google.android.play:app-update:2.1.0" />
+        <framework src="com.google.android.gms:play-services-tasks:18.0.2" />
         <config-file parent="/*" target="res/xml/config.xml">
             <feature name="InAppUpdateManager">
                 <param name="android-package" value="InAppUpdateManager.InAppUpdateManager" />


### PR DESCRIPTION
Updated the Play Core dependency to use the new modular app-update library.

Changes:
- Replaced com.google.android.play:core:1.9.1 with com.google.android.play:app-update:2.1.0
- Added com.google.android.gms:play-services-tasks:18.0.2 dependency

This update aligns with Google's new modular Play Core libraries and fixes compatibility issues with newer Android versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android dependencies to use the latest libraries for app updates and task services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->